### PR TITLE
Fix GitHub URLs in book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -30,8 +30,8 @@ additional-js = [
 curly-quotes = true
 print = { enable = true }
 fold = { enable = true, level = 0 }
-git-repository-url = "https://github.com/ISSOtm/gb-asm-tutorial"
-edit-url-template = "https://github.com/ISSOtm/gb-asm-tutorial/edit/master/{path}"
+git-repository-url = "https://github.com/ISSOtm/gb-asm-tutorial-v2"
+edit-url-template = "https://github.com/ISSOtm/gb-asm-tutorial-v2/edit/master/{path}"
 site-url = "/gb-asm-tutorial-v2/"
 
 [output.linkcheck]


### PR DESCRIPTION
This makes it easier to contribute while the new tutorial is still in the staging area.