### PR TITLE
Document the `jr` instruction and use it in hello-world.asm

### DIFF
--- a/src/assets/hello-world.asm
+++ b/src/assets/hello-world.asm
@@ -19,7 +19,7 @@ EntryPoint:
 WaitVBlank:
 	ld a, [rLY]
 	cp 144
-	jp c, WaitVBlank
+	jr c, WaitVBlank
 
 	; Turn the LCD off
 	ld a, 0
@@ -39,7 +39,7 @@ CopyTiles:
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, CopyTiles
+	jr nz, CopyTiles
 ; ANCHOR_END: memcpy
 
 	; Copy the tilemap
@@ -53,7 +53,7 @@ CopyTilemap:
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, CopyTilemap
+	jr nz, CopyTilemap
 
 	; Turn the LCD on
 	ld a, LCDC_ON | LCDC_BG_ON
@@ -66,7 +66,7 @@ CopyTilemap:
 ; ANCHOR_END: bgp_write
 
 Done:
-	jp Done
+	jr Done
 
 
 SECTION "Tile data", ROM0

--- a/src/part1/jumps.md
+++ b/src/part1/jumps.md
@@ -27,8 +27,9 @@ There are four of them:
 | Call          | `call`   | Call a subroutine            |
 | Return        | `ret`    | Return from a subroutine     |
 
-We will focus on `jp` for now.
-`jp`, such as the one line {{#line_no_of "^\s*jp" ../assets/hello-world.asm}}, simply sets PC to its argument, jumping execution there.
+We will focus on the first two, `jp` and `jr`, for now.
+
+`jp`, such as the one on line {{#line_no_of "^\s*jp" ../assets/hello-world.asm}}, simply sets PC to its argument, jumping execution there.
 In other words, after executing `jp EntryPoint` (line {{#line_no_of "^\s*jp EntryPoint" ../assets/hello-world.asm}}), the next instruction executed is the one below `EntryPoint` (line <!-- should be {{#line_no_of "^\s*EntryPoint:" ../assets/hello-world.asm}} + 1 --> 11).
 
 :::tip:🤔
@@ -37,6 +38,8 @@ You may be wondering what is the point of that specific `jp`.
 Don't worry, we will see later why it's required.
 
 :::
+
+`jr`, such as the one on line {{#line_no_of "^\s*jr" ../assets/hello-world.asm}}, is functionally the same as `jp`. However, it sets PC *relative* to the current PC value, and can only jump execution forward or backward by 128 bytes---a short distance given that each instruction takes one to three bytes. The advantage of `jr` is that it takes up two bytes instead of three like `jp` (since it encodes a one-byte relative distance instead of a two-byte absolute address), and also takes one CPU cycle less than `jp` to execute, so it's commonly used when you know that a jump will be short.
 
 ## Conditional jumps
 
@@ -94,7 +97,7 @@ There are four "conditions":
 | Carry    | `c`      | C is set (last operation overflowed)                |
 | No carry | `nc`     | C is not set (last operation did not overflow)      |
 
-Thus, `jp nz, CopyTiles` can be read as "if the Z flag is not set, then jump to `CopyTiles`".
+Thus, `jr nz, CopyTiles` can be read as "if the Z flag is not set, then jump to `CopyTiles`".
 Since we're jumping _backwards_, we will repeat the instructions again: we have just created a **loop**!
 
 Okay, we've been talking about the code a lot, and we have seen it run, but we haven't really seen _how_ it runs.


### PR DESCRIPTION
Following the discussion in #146, here's my try at introducing the `jr` instruction to beginners.

<img width="777" height="600" alt="image" src="https://github.com/user-attachments/assets/a7fdcacd-1c0f-4ee7-8da3-cee95f099fb8" />

I think that a section titled "Jumps" is the obvious place to explain how relative jumps work. And they're clearly relevant and idiomatic right away in the hello-world.asm code -- anybody coming onto the gbdev Discord for help, or browsing the source code of other games, would see idioms like `jr c, WaitVBlank`, not `jp c, WaitVBlank`.

Furthermore, consider the concepts used and introduced in this paragraph. Section I.7 "Memory" already described the CPU in more than sufficient detail, and noted that instructions take up one or more bytes. And "distance relative to the current point" isn't even a programming concept, it's just... how distance works. The only new-ish concept is the word "cycle" to refer to how long instructions take to execute, but it shouldn't come as a surprise that doing things takes time -- we don't have to discuss at this point *why* it's faster (because there's one fewer byte to read, so the time is saved by reading less).

Fixes #146 since we'd no longer need to deoptimize/pessimize Unbricked with `jp` everywhere. (I'm not updating the larger projects in parts II and III to use `jr` consistently, but with this PR, it's at least be an *option* for anyone maintaining that code.)