### PR TITLE
Rename Memcopy to MemCopy in P2

### DIFF
--- a/src/part2/functions.md
+++ b/src/part2/functions.md
@@ -4,7 +4,7 @@ So far, we have only written a single "flow" of code, but we can already spot so
 Let's use **functions** to "factor out" code!
 
 For example, in three places, we are copying chunks of memory around.
-Let's write a function below the `jp Main`, and let's call it `Memcpy`, like [the similar C function](https://man7.org/linux/man-pages/man3/memcpy.3.html):
+Let's write a function below the `jp Main`, and let's call it `MemCopy`, like the similar C function [`memcpy`](https://man7.org/linux/man-pages/man3/memcpy.3.html):
 
 ```rgbasm,linenos,start={{#line_no_of "" ../../unbricked/functions/main.asm:memcpy}}
 {{#include ../../unbricked/functions/main.asm:memcpy}}
@@ -20,8 +20,8 @@ Notice the comment above the function, explaining which registers it takes as in
 This comment is important so that you know how to interface with the function; assembly has no formal parameters, so comments explaining them are even more important than with other languages.
 We'll see more of those as we progress.
 
-There are three places in the initialization code where we can use the `Memcpy` function.
-Find each of these copy loops and replace them with a call to `Memcpy`; for this, we use the `call` instruction.
+There are three places in the initialization code where we can use the `MemCopy` function.
+Find each of these copy loops and replace them with a call to `MemCopy`; for this, we use the `call` instruction.
 The registers serve as parameters to the function, so we'll leave them as-is.
 
 <div class="table-wrapper"><table><thead><tr><th>Before</th><th>After</th></tr></thead><tbody><tr><td>

--- a/src/part2/input.md
+++ b/src/part2/input.md
@@ -4,7 +4,7 @@ We have the building blocks of a game here, but we're still lacking player input
 A game that plays itself isn't very much fun, so let's fix that.
 
 Paste this code below your `Main` loop.
-Like `Memcpy`, this is a function that can be reused from different places, using the `call` instruction.
+Like `MemCopy`, this is a function that can be reused from different places, using the `call` instruction.
 
 ```rgbasm,linenos,start={{#line_no_of "" ../../unbricked/input/main.asm:input-routine}}
 {{#include ../../unbricked/input/main.asm:input-routine}}

--- a/src/part2/title-screen.md
+++ b/src/part2/title-screen.md
@@ -13,7 +13,7 @@ Then copy and paste the following after waiting for VBlank:
 ```rgbasm,linenos,start={{#line_no_of "" ../../unbricked/title-screen/main.asm:title_screen}}
 {{#include ../../unbricked/title-screen/main.asm:title_screen}}
 ```
-Note that we are using our `Memcopy` function from the [Functions](./functions.md) lesson! Isn't it handy to have reusable code? We are also using our `UpdateKeys` function from the [Input](./input.md) lesson to determine when to stop displaying the title screen and move on to the game itself. To do so, we loop until the start button has been pressed. 
+Note that we are using our `MemCopy` function from the [Functions](./functions.md) lesson! Isn't it handy to have reusable code? We are also using our `UpdateKeys` function from the [Input](./input.md) lesson to determine when to stop displaying the title screen and move on to the game itself. To do so, we loop until the start button has been pressed. 
 
 And just like that we have ourselves a title screen! 
 

--- a/unbricked/audio/main.asm
+++ b/unbricked/audio/main.asm
@@ -27,25 +27,25 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; Copy the tilemap
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 
 	; Copy the paddle tile
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 
 	; Copy the ball tile
 	ld de, Ball
 	ld hl, $8010
 	ld bc, BallEnd - Ball
-	call Memcopy
+	call MemCopy
 
 	xor a, a
 	ld b, 160
@@ -351,14 +351,14 @@ Input:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 ; ANCHOR: bounce-sound

--- a/unbricked/bcd/main.asm
+++ b/unbricked/bcd/main.asm
@@ -31,25 +31,25 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; Copy the tilemap
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 
 	; Copy the paddle tile
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 
 	; Copy the ball tile
 	ld de, Ball
 	ld hl, $8010
 	ld bc, BallEnd - Ball
-	call Memcopy
+	call MemCopy
 
 	xor a, a
 	ld b, 160
@@ -382,14 +382,14 @@ Input:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 Tiles:

--- a/unbricked/bricks/main.asm
+++ b/unbricked/bricks/main.asm
@@ -27,25 +27,25 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; Copy the tilemap
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 
 	; Copy the paddle tile
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 
 	; Copy the ball tile
 	ld de, Ball
 	ld hl, $8010
 	ld bc, BallEnd - Ball
-	call Memcopy
+	call MemCopy
 
 	xor a, a
 	ld b, 160
@@ -347,14 +347,14 @@ Input:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 Tiles:

--- a/unbricked/collision/main.asm
+++ b/unbricked/collision/main.asm
@@ -21,26 +21,26 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; Copy the tilemap
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 
 	; Copy the paddle tile
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 
 ; ANCHOR: ball-copy
 	; Copy the ball tile
 	ld de, Ball
 	ld hl, $8010
 	ld bc, BallEnd - Ball
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: ball-copy
 
 	xor a, a
@@ -334,14 +334,14 @@ UpdateKeys:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 Tiles:

--- a/unbricked/functions/main.asm
+++ b/unbricked/functions/main.asm
@@ -22,7 +22,7 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_tiles
 
 ; ANCHOR: copy_map
@@ -30,7 +30,7 @@ WaitVBlank:
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_map
 
 ; ANCHOR: copy_paddle
@@ -38,7 +38,7 @@ WaitVBlank:
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_paddle
 
 	xor a, a
@@ -104,14 +104,14 @@ WaitVBlank2:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 ; ANCHOR_END: memcpy
 

--- a/unbricked/input/main.asm
+++ b/unbricked/input/main.asm
@@ -22,7 +22,7 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_tiles
 
 ; ANCHOR: copy_map
@@ -30,7 +30,7 @@ WaitVBlank:
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_map
 
 ; ANCHOR: copy_paddle
@@ -38,7 +38,7 @@ WaitVBlank:
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_paddle
 
 	xor a, a
@@ -163,14 +163,14 @@ UpdateKeys:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 ; ANCHOR_END: memcpy
 

--- a/unbricked/serial-link/demo.asm
+++ b/unbricked/serial-link/demo.asm
@@ -97,7 +97,7 @@ WaitVBlank:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; clear BG tilemap
 	ld hl, $9800
@@ -663,14 +663,14 @@ Input:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 Tiles:

--- a/unbricked/serial-link/main.asm
+++ b/unbricked/serial-link/main.asm
@@ -269,25 +269,25 @@ EntryPoint:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 
 	; Copy the tilemap
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 
 	; Copy the paddle tile
 	ld de, Paddle
 	ld hl, $8000
 	ld bc, PaddleEnd - Paddle
-	call Memcopy
+	call MemCopy
 
 	; Copy the ball tile
 	ld de, Ball
 	ld hl, $8010
 	ld bc, BallEnd - Ball
-	call Memcopy
+	call MemCopy
 
 	xor a, a
 	ld b, 160
@@ -677,14 +677,14 @@ Input:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 
 Tiles:

--- a/unbricked/title-screen/main.asm
+++ b/unbricked/title-screen/main.asm
@@ -30,12 +30,12 @@ TitleScreen:
 	ld de, Unbricked_Title_Screen_Tileset_Begin
 	ld hl, $9000
 	ld bc, Unbricked_Title_Screen_Tileset_End - Unbricked_Title_Screen_Tileset_Begin
-	call Memcopy
+	call MemCopy
 
 	ld de, Unbricked_Title_Screen_Map_Begin
 	ld hl, $9800
 	ld bc, Unbricked_Title_Screen_Map_End - Unbricked_Title_Screen_Map_Begin
-	call Memcopy
+	call MemCopy
 
 	; Turn the LCD on
 	ld a, LCDC_ON | LCDC_BG_ON
@@ -77,7 +77,7 @@ ClearVRAM:
 	ld de, Tiles
 	ld hl, $9000
 	ld bc, TilesEnd - Tiles
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_tiles
 
 ; ANCHOR: copy_map
@@ -85,7 +85,7 @@ ClearVRAM:
 	ld de, Tilemap
 	ld hl, $9800
 	ld bc, TilemapEnd - Tilemap
-	call Memcopy
+	call MemCopy
 ; ANCHOR_END: copy_map
 
 	; Turn the LCD on
@@ -104,14 +104,14 @@ Done:
 ; @param de: Source
 ; @param hl: Destination
 ; @param bc: Length
-Memcopy:
+MemCopy:
 	ld a, [de]
 	ld [hli], a
 	inc de
 	dec bc
 	ld a, b
 	or a, c
-	jp nz, Memcopy
+	jp nz, MemCopy
 	ret
 ; ANCHOR_END: memcpy
 


### PR DESCRIPTION
Corrects the inconsistency noted in #85, following the suggestions by @Rangi42.

Fixes #85